### PR TITLE
virhostcpu: Fix potential use of unallocated memory

### DIFF
--- a/src/util/virhostcpu.c
+++ b/src/util/virhostcpu.c
@@ -1091,22 +1091,26 @@ virHostCPUGetMap(unsigned char **cpumap,
 {
     g_autoptr(virBitmap) cpus = NULL;
     int ret = -1;
-    int dummy;
 
     virCheckFlags(0, -1);
 
+    ret = virHostCPUGetCount();
+
     if (!cpumap && !online)
-        return virHostCPUGetCount();
+        return ret;
 
     if (!(cpus = virHostCPUGetOnlineBitmap()))
         goto cleanup;
 
-    if (cpumap)
-        virBitmapToData(cpus, cpumap, &dummy);
+    if (cpumap) {
+        int len = (ret + CHAR_BIT) / CHAR_BIT;
+        *cpumap = g_new0(unsigned char, len);
+        virBitmapToDataBuf(cpus, *cpumap, len);
+    }
+
     if (online)
         *online = virBitmapCountBits(cpus);
 
-    ret = virHostCPUGetCount();
 
  cleanup:
     if (ret < 0 && cpumap)


### PR DESCRIPTION
In case of a host that has a large number of cpus offline the count of host cpus and the last bit set in the virHostCPUGetOnlineBitmap might diverge significantly. This can e.g. be the case when disabeling smt via /sys/devices/system/cpu/smt/control.

On the host this looks like:
```
$ cat /sys/devices/system/cpu/present
0-255
$ cat /sys/devices/system/cpu/online
0-127
```

However in this case virBitmapToData previously only allocated 16 bytes for the output bitmap. This is becase the last set bit is on the 15th byte.

Users of virHostCPUGetMap however rely on the "cpumap" containing enough space for all existing cpus (so they would expect 32 bytes in this case). E.g. cmdNodeCpuMap relies on this for its output. It will then actually read 32 bytes from the start of the "cpumap" address where in this case the last 16 of these bytes are uninitialized.

This manifests itself in flapping outputs of "virsh nodecpumap --pretty" like:
```
$ virsh nodecpumap --pretty
CPUs present:   256
CPUs online:    128
CPU map:        0-127,192,194,202

$ virsh nodecpumap --pretty
CPUs present:   256
CPUs online:    128
CPU map:        0-127,192,194,197

$ virsh nodecpumap --pretty
CPUs present:   256
CPUs online:    128
CPU map:        0-127,192,194,196-197
```

This in turn potentially causes users of this data to report wrong cpu counts.

Note that this only seems to happen with at least 256 phyiscal cpus where at least 128 are offline.

We fix this by preallocating the expected bitmap size.

## Summary by Sourcery

Fix potential memory allocation issue in virHostCPUGetMap when handling systems with a large number of CPUs

Bug Fixes:
- Ensure proper memory allocation for CPU bitmap when the number of CPUs is large, preventing potential uninitialized memory access

Enhancements:
- Modify virHostCPUGetMap to preallocate bitmap size based on total CPU count
- Improve robustness of CPU mapping for systems with many physical CPUs